### PR TITLE
- Expose "afterCloudRender" function call to user (on-rendered attrib…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # angular-tag-cloud changelog
 
+
+## v0.3.3 (24/01/2017)
+- Expose "afterCloudRender" function call to user (on-rendered attribute).
+- Fix - run afterCloudRender.call() only after cloud render .(instead on before and after) . [yonatan20](https://github.com/yonatan20).
+
 ## v0.3.2 (22/01/2017)
 - Expose the "delayed-mode" to user.
 - Removed redundant Second call for drawing the words. [yonatan20](https://github.com/yonatan20).

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ True - 10 ms delay.
 False - No delay.
 Undifened - True only if there is more then 50 words.
 
+You can pass function that will invoke after word cloud is rendered:
+```html
+<ng-tag-cloud  on-rendered="ctrl.myFunc()"></ng-tag-cloud>
+```
+
 ## Examples
 
 Please check the examples directory to get the exact idea of what i am talking about. It's always better to check examples. 

--- a/src/ng-tag-cloud.js
+++ b/src/ng-tag-cloud.js
@@ -22,7 +22,8 @@ ngTagCloud.directive("ngTagCloud",["$timeout","$log",function($timeout,$log){
            cloudHeight: '=?',
            cloudOverflow: '=?',
            cloudData: '=',
-           delayedMode:'=?'
+           delayedMode:'=?',
+           onRendered: '&'
        },
        template: "<div id='ng-tag-cloud' class='ng-tag-cloud'></div>",
        link: function($scope,element,attrs){
@@ -44,6 +45,12 @@ ngTagCloud.directive("ngTagCloud",["$timeout","$log",function($timeout,$log){
                height: $scope.cloudHeight?$scope.cloudHeight:"300",
                delayedMode: ($scope.delayedMode!==undefined)?$scope.delayedMode:($scope.cloudData.length > 50)
            };
+
+           //Enable to execute function after cloud rendered
+           options.afterCloudRender = function() {
+               $scope.onRendered();
+           };
+
            // Reference to the container element
            var $this = angular.element(element)[0];
            // Namespace word ids to avoid collisions between multiple clouds
@@ -246,7 +253,7 @@ ngTagCloud.directive("ngTagCloud",["$timeout","$log",function($timeout,$log){
                 if (index < word_array.length) {
                   drawOneWord(index, word_array[index]);
                   $timeout(function(){drawOneWordDelayed(index + 1);}, 10);
-                } else {
+                } else if(index != 0){
                   if (typeof(options.afterCloudRender) === "function") {
                     options.afterCloudRender.call($this);
                   }


### PR DESCRIPTION
- Expose "afterCloudRender" function call to user (on-rendered attribute).

- Fix - run afterCloudRender.call() only after cloud render .(instead on before and after)